### PR TITLE
Improve codeblock regex

### DIFF
--- a/Auto.js
+++ b/Auto.js
@@ -35,7 +35,7 @@ client.on('message', msg => {
 	if (!msg.channel.permissionsFor(client.user).has(['ADD_REACTIONS', 'READ_MESSAGE_HISTORY'])) return;
 	const parsed = codeblock.exec(msg.content);
 	const code = {
-		code: parsed[2].trim(),
+		code: parsed[2],
 		lang: parsed[1]
 	};
 	client.registry.resolveCommand('lint:default').run(msg, { code }, true);
@@ -48,7 +48,7 @@ client.on('messageUpdate', (oldMsg, msg) => {
 	if (!msg.channel.permissionsFor(client.user).has(['ADD_REACTIONS', 'READ_MESSAGE_HISTORY'])) return;
 	const parsed = codeblock.exec(msg.content);
 	const code = {
-		code: parsed[2].trim(),
+		code: parsed[2],
 		lang: parsed[1]
 	};
 	client.registry.resolveCommand('lint:default').run(msg, { code }, true, true);
@@ -63,7 +63,7 @@ client.on('messageReactionAdd', (reaction, user) => {
 	if (!codeblock.test(msg.content)) return;
 	const parsed = codeblock.exec(msg.content);
 	const code = {
-		code: parsed[2].trim(),
+		code: parsed[2],
 		lang: parsed[1]
 	};
 	client.registry.resolveCommand('lint:default').run(msg, { code });

--- a/Auto.js
+++ b/Auto.js
@@ -35,8 +35,8 @@ client.on('message', msg => {
 	if (!msg.channel.permissionsFor(client.user).has(['ADD_REACTIONS', 'READ_MESSAGE_HISTORY'])) return;
 	const parsed = codeblock.exec(msg.content);
 	const code = {
-		code: parsed[3].trim(),
-		lang: parsed[2]
+		code: parsed[2].trim(),
+		lang: parsed[1]
 	};
 	client.registry.resolveCommand('lint:default').run(msg, { code }, true);
 });
@@ -48,8 +48,8 @@ client.on('messageUpdate', (oldMsg, msg) => {
 	if (!msg.channel.permissionsFor(client.user).has(['ADD_REACTIONS', 'READ_MESSAGE_HISTORY'])) return;
 	const parsed = codeblock.exec(msg.content);
 	const code = {
-		code: parsed[3].trim(),
-		lang: parsed[2]
+		code: parsed[2].trim(),
+		lang: parsed[1]
 	};
 	client.registry.resolveCommand('lint:default').run(msg, { code }, true, true);
 });
@@ -63,8 +63,8 @@ client.on('messageReactionAdd', (reaction, user) => {
 	if (!codeblock.test(msg.content)) return;
 	const parsed = codeblock.exec(msg.content);
 	const code = {
-		code: parsed[3].trim(),
-		lang: parsed[2]
+		code: parsed[2].trim(),
+		lang: parsed[1]
 	};
 	client.registry.resolveCommand('lint:default').run(msg, { code });
 });

--- a/Auto.js
+++ b/Auto.js
@@ -10,7 +10,7 @@ const client = new CommandoClient({
 	disabledEvents: ['TYPING_START']
 });
 const emoji = require('./assets/json/emoji');
-const codeblock = /(`{3})(js|javascript)?\n?([\s\S]*)\1/i;
+const codeblock = /```(?:(js|javascript)\n)?\s*([^]+?)\s*```/i;
 
 client.registry
 	.registerDefaultTypes()

--- a/types/code.js
+++ b/types/code.js
@@ -1,5 +1,5 @@
 const { ArgumentType } = require('discord.js-commando');
-const codeblock = /(`{3})(js|javascript)?\n?([\s\S]*)\1/i;
+const codeblock = /```(?:(js|javascript)\n)?\s*([^]+?)\s*```/i;
 
 class CodeArgumentType extends ArgumentType {
 	constructor(client) {
@@ -22,8 +22,8 @@ class CodeArgumentType extends ArgumentType {
 		if (codeblock.test(value)) {
 			const parsed = codeblock.exec(value);
 			return {
-				code: parsed[3].trim(),
-				lang: parsed[2]
+				code: parsed[2],
+				lang: parsed[1]
 			};
 		}
 		return null;


### PR DESCRIPTION
This change does several things:
- Removes leading/trailing whitespace
- Only matches the language if followed by a newline (matches Discord's behaviour)
- Fixes `````` being identified as a codeblock