### PR TITLE
Use a single function for the message events to keep them DRY

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "auto",
-	"version": "2.1.1",
+	"version": "3.0.0",
 	"description": "A code scanner Discord bot.",
 	"main": "Auto.js",
 	"scripts": {


### PR DESCRIPTION
* Made a variable for the `message` and `messageUpdate` event since they shared almost the exact same code
* Added the `<auto:no-scan>` topic config to disable auto-linting for channels that don't need them
* Renamed the `<blocked>` channel topic config to `<auto:block-all>`
* Bumped up the package.json version to 3.0.0 since it'd be a breaking change due to the change mentioned above